### PR TITLE
Moved api key to plist (implements #75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ xcuserdata
 .DS_Store
 
 settings.plist
+apikey.plist
 Assets/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ We encourage anyone who is interested in contributing to Pet Adoption to do so! 
 Our repository has two main branches: `master` and `develop`.  `master` is reserved for releases and, as such, only administrators are allowed to merge into master.  All current work is done off the `develop` branch.
 
 ### Code for Orlando Members
-If you are currently a member of Code for Orlando (ie. you have access to the Code for Orlando Github repo), we ask that you create a branch off of `develop`.  You can do this by using the command `git checkout -b [name-of-branch]`. (Make sure you do this from `develop`).  You can name the branch anything you'd like, but we encourage a GitFlow style branch name: `feature/[what-did-you-work-on]`.  When you are ready to commit, push your changes using the command `git push origin [name-of-branch]` and then submit a pull request.  If you are working on a specific issue (which you should be! :P ), reference the issue number in the pull request.
+If you are currently a member of Code for Orlando (ie. you have access to the Code for Orlando Github repo), we ask that you create a branch off of `develop`.  You can do this by using the command `git checkout -b [name-of-branch]`. You can name the branch anything you'd like, but we encourage a GitFlow style branch name: `feature/[what-did-you-work-on]`.  When you are ready to commit, push your changes using the command `git push origin [name-of-branch]` and then submit a pull request.  If you are working on a specific issue (which you should be! :P ), reference the issue number in the pull request.
 
 By following these guidelines, we will be able to perform code reviews on all commits before merging with the `develop` branch!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,23 @@
 
 We encourage anyone who is interested in contributing to Pet Adoption to do so!  In order to ensure good code quality, there are some guidelines we would like to adhere to when contributing to this project. 
 
-### Code for Orlando Members
-If you are currently a member of Code for Orlando (ie. you have access to the Code for Orlando Github repo), we ask that you not push any commits directly into master.  Please create a branch first.  You can do this by using the command `git checkout -b [name-of-branch]`.  You can name the branch anything you'd like, but we encourage using the following: `[your-github-username]/develop`.  When you are ready to commit, push your changes using the command `git push origin [name-of-branch]` and then submit a pull request.  If you are working on a specific issue (which you should be! :P ), reference the issue number in the pull request.
+---
 
-By following these guidelines, we will be able to perform code reviews on all commits before merging with the master branch!
+### Project Organization
+Our repository has two main branches: `master` and `develop`.  `master` is reserved for releases and, as such, only administrators are allowed to merge into master.  All current work is done off the `develop` branch.
+
+### Code for Orlando Members
+If you are currently a member of Code for Orlando (ie. you have access to the Code for Orlando Github repo), we ask that you create a branch off of `develop`.  You can do this by using the command `git checkout -b [name-of-branch]`. (Make sure you do this from `develop`).  You can name the branch anything you'd like, but we encourage a GitFlow style branch name: `feature/[what-did-you-work-on]`.  When you are ready to commit, push your changes using the command `git push origin [name-of-branch]` and then submit a pull request.  If you are working on a specific issue (which you should be! :P ), reference the issue number in the pull request.
+
+By following these guidelines, we will be able to perform code reviews on all commits before merging with the `develop` branch!
 
 ### Non-Code for Orlando Members
 For anyone not currently a member of Code for Orlando, we still encourage you to contribute if you are interested!  (Of course, we strongly encourage you to come to a meetup and meet the rest of us!)  If you would like to contribute, go ahead and fork the repo.  Make your changes and push them to your forked repo.  Then you can submit a pull request on Github.
+
+---
+
+### IMPORTANT NOTE TO CONTRIBUTORS
+v1.0 of the Pet Adoption app uses the PetFinder API. As such, an API key is required.  This project does not include an API key by default, so you **will** need to get one.  You can get a free developers API key for PetFinder at https://www.petfinder.com/developers/api-key.  You will need to create a free account in order to get an API key.
+
+Once you have your API key, you will need to create an `apikey.plist` file.  For your convenience, there is a file called `apikey.plist.example` provided.  Simply create a copy of this file, rename it to `apikey.plist`, open it, and enter your API key into the appropriate place.  `apikey.plist` is include in the `.gitignore` file, so you don't need to worry about removing this file before submitting pull requests but please make sure that you don't remove the `apikey.plist.example` file in your PRs.
+

--- a/PetAdoption-iOS/PetAdoption-iOS.xcodeproj/project.pbxproj
+++ b/PetAdoption-iOS/PetAdoption-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		94586CAB2007AE57002B6084 /* PFPhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94586CAA2007AE57002B6084 /* PFPhoto.swift */; };
 		94586CAD2007AF6E002B6084 /* PFContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94586CAC2007AF6E002B6084 /* PFContact.swift */; };
 		94586CAF200822BF002B6084 /* PFGender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94586CAE200822BF002B6084 /* PFGender.swift */; };
+		94EA0483202BCF5B00AFCF55 /* apikey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94EA0482202BCF5B00AFCF55 /* apikey.plist */; };
+		94EA0484202BCF5B00AFCF55 /* apikey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94EA0482202BCF5B00AFCF55 /* apikey.plist */; };
 		97C5226AC9AFB7547023F371 /* Pods_PetAdoptionTransportKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBB921F8A0328C363307C66E /* Pods_PetAdoptionTransportKit.framework */; };
 		D013BFA51C716B7E007C8808 /* ImageGalleryView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D013BFA41C716B7E007C8808 /* ImageGalleryView.xib */; };
 		D013BFA71C717935007C8808 /* ImageGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D013BFA61C717935007C8808 /* ImageGalleryView.swift */; };
@@ -155,6 +157,7 @@
 		94586CAA2007AE57002B6084 /* PFPhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFPhoto.swift; sourceTree = "<group>"; };
 		94586CAC2007AF6E002B6084 /* PFContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFContact.swift; sourceTree = "<group>"; };
 		94586CAE200822BF002B6084 /* PFGender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFGender.swift; sourceTree = "<group>"; };
+		94EA0482202BCF5B00AFCF55 /* apikey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = apikey.plist; sourceTree = "<group>"; };
 		AB77A283D0B7D820C44F8CAD /* Pods-PetAdoption-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PetAdoption-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-PetAdoption-iOS/Pods-PetAdoption-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		CBB921F8A0328C363307C66E /* Pods_PetAdoptionTransportKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PetAdoptionTransportKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D013BFA41C716B7E007C8808 /* ImageGalleryView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = ImageGalleryView.xib; path = Nibs/ImageGalleryView.xib; sourceTree = "<group>"; };
@@ -421,6 +424,7 @@
 				D0950ACE1C618C2F002E198C /* Assets.xcassets */,
 				D0950AD01C618C2F002E198C /* LaunchScreen.storyboard */,
 				D0950AD31C618C2F002E198C /* Info.plist */,
+				94EA0482202BCF5B00AFCF55 /* apikey.plist */,
 			);
 			path = "PetAdoption-iOS";
 			sourceTree = "<group>";
@@ -766,6 +770,7 @@
 				D0950AF61C618CE4002E198C /* Podfile in Resources */,
 				D0950ACD1C618C2F002E198C /* Main.storyboard in Resources */,
 				D04088621C94BEE000A53389 /* OpenSans-LightItalic.ttf in Resources */,
+				94EA0483202BCF5B00AFCF55 /* apikey.plist in Resources */,
 				D040885D1C94BEE000A53389 /* OpenSans-BoldItalic.ttf in Resources */,
 				D04088641C94BEE000A53389 /* OpenSans-Semibold.ttf in Resources */,
 				D04088611C94BEE000A53389 /* OpenSans-Light.ttf in Resources */,
@@ -797,6 +802,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				94EA0484202BCF5B00AFCF55 /* apikey.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PetAdoption-iOS/PetAdoption-iOS/apikey.plist.example
+++ b/PetAdoption-iOS/PetAdoption-iOS/apikey.plist.example
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>petfinder_api_key</key>
+	<string>enter your API key here</string>
+</dict>
+</plist>

--- a/PetAdoption-iOS/PetAdoptionTransportKit/PTKRequestManager.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PTKRequestManager.swift
@@ -27,8 +27,6 @@ public typealias PTKRequestImageComplete = (_ image: UIImage?, _ error: NSError?
 private let PFBaseURL = "http://api.petfinder.com/"
 private let PFPetFind = "\(PFBaseURL)pet.find"
 
-private let API_KEY = "ca74980f2ab686e10a43095a87d24d45"
-
 public typealias PFRequestPetsComplete = (_ pets: [PFPet]?, _ error: Error?) -> Void
 
 public class PTKRequestManager: NSObject {
@@ -82,7 +80,7 @@ public class PTKRequestManager: NSObject {
     
     public func request(PetFinderPetsFrom location: String, withCompletion completion: @escaping PFRequestPetsComplete) {
         let parameters = [
-            "key" : API_KEY,
+            "key" : getApiKey(),
             "format" : "json",
             "location" : location
         ]
@@ -147,5 +145,23 @@ public class PTKRequestManager: NSObject {
             }
             
         }
+    }
+    
+    private func getApiKey() -> String {
+        guard let path = Bundle.main.path(forResource: "apikey", ofType: "plist") else {
+            fatalError("You seem to be missing an apikey.plist file.  This is required to store your API key for PetFinder.  You may use apikey.plist.example as a starting point to creating this file.")
+        }
+        
+        if let plist = NSDictionary(contentsOfFile: path) {
+            if let apikey = plist["petfinder_api_key"] as? String {
+                if apikey.isEmpty {
+                    print("The API key appears to be missing from your apikey.plist file.  Please make sure there is a valid API key there.")
+                }
+                
+                return apikey
+            }
+        }
+        
+        fatalError("There does not appear to be a valid PetFinder API key.")
     }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -25,6 +25,11 @@ John Li (johnliglobal@gmail.com) (slack: johnleeroy)
 
 If you do not have CocoaPods installed, you can do so by opening Terminal and entering: `sudo gem install cocoapods`.  Once you have done that, navigate to the project directory and run `pod install`.  Make sure you open the .xcworkspace for the project.
 
+### IMPORTANT NOTE TO CONTRIBUTORS
+v1.0 of the Pet Adoption app uses the PetFinder API. As such, an API key is required.  This project does not include an API key by default, so you **will** need to get one.  You can get a free developers API key for PetFinder at https://www.petfinder.com/developers/api-key.  You will need to create a free account in order to get an API key.
+
+Once you have your API key, you will need to create an `apikey.plist` file.  For your convenience, there is a file called `apikey.plist.example` provided.  Simply create a copy of this file, rename it to `apikey.plist`, open it, and enter your API key into the appropriate place.  `apikey.plist` is include in the `.gitignore` file, so you don't need to worry about removing this file before submitting pull requests but please make sure that you don't remove the `apikey.plist.example` file in your PRs.
+
 ## Want to contribute?
 ------
 If you'd like to contribute, check out our [Contributing](CONTRIBUTING.md) page for more details.


### PR DESCRIPTION
I created a new file called `apikey.plist`.  The PetFinder API key will now live in this file.  This file is included in the project with the appropriate targets.  Code was added to `PTKRequestManager.swift` to pull the key from this plist.

In order to keep the API key secret, `apikey.plist` was included in `.gitignore`.  In order to help contributors, a template file called `apikey.plist.example` was also created with a placeholder for the api key.  Instructions were added to the README and Contributing files to instruct contributors on how to use this template to create the actual `apikey.plist` that is now required for the app.