### PR TITLE
Fixed hard crash caused by bad API return

### DIFF
--- a/PetAdoption-iOS/PetAdoptionTransportKit/PFAnimalType.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PFAnimalType.swift
@@ -18,6 +18,7 @@ public enum PFAnimalType: String, CustomStringConvertible
     case horse = "Horse"
     case rabbit = "Rabbit"
     case reptile = "Reptile"
+    case unknown
 
     public var description: String
     {
@@ -31,6 +32,7 @@ public enum PFAnimalType: String, CustomStringConvertible
             case .horse: return "Horse"
             case .rabbit: return "Rabbit"
             case .reptile: return "Reptile"
+            case .unknown: return "Unknown"
         }
     }
 }

--- a/PetAdoption-iOS/PetAdoptionTransportKit/PFGender.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PFGender.swift
@@ -12,6 +12,7 @@ public enum PFGender: String, CustomStringConvertible
 {
     case male = "M"
     case female = "F"
+    case unknown
     
     public var description: String
     {
@@ -19,6 +20,7 @@ public enum PFGender: String, CustomStringConvertible
         {
             case .male: return "Male"
             case .female: return "Female"
+            case .unknown: return "Unknown"
         }
     }
 }

--- a/PetAdoption-iOS/PetAdoptionTransportKit/PFPet.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PFPet.swift
@@ -31,10 +31,10 @@ public struct PFPet
     init(json: JSON)
     {
         self.name = json["name"]["$t"].string ?? ""
-        self.animalType = PFAnimalType(rawValue: json["animal"]["$t"].stringValue)!
-        self.age = PFPetAgeType(rawValue: json["age"]["$t"].stringValue)!
-        self.sex = PFGender(rawValue: json["sex"]["$t"].stringValue)!
-        self.size = PFPetSizeType(rawValue: json["size"]["$t"].stringValue)!
+        self.animalType = PFAnimalType(rawValue: json["animal"]["$t"].stringValue) ?? .unknown
+        self.age = PFPetAgeType(rawValue: json["age"]["$t"].stringValue) ?? .unknown
+        self.sex = PFGender(rawValue: json["sex"]["$t"].stringValue) ?? .unknown
+        self.size = PFPetSizeType(rawValue: json["size"]["$t"].stringValue) ?? .unknown
         self.description = json["description"]["$t"].string ?? ""
         self.status = json["status"]["$t"].string ?? ""
         self.contact = PFContact(json: json["contact"])
@@ -89,7 +89,7 @@ public struct PFPet
         {
             self.breeds.append(breed)
         }
-        else if let breeds = json["breed"]["breed"].array
+        else if let breeds = json["breeds"]["breed"].array
         {
             for breedJson in breeds
             {

--- a/PetAdoption-iOS/PetAdoptionTransportKit/PFPetAgeType.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PFPetAgeType.swift
@@ -14,4 +14,5 @@ public enum PFPetAgeType: String
     case young = "Young"
     case adult = "Adult"
     case senior = "Senior"
+    case unknown
 }

--- a/PetAdoption-iOS/PetAdoptionTransportKit/PFPetSizeType.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PFPetSizeType.swift
@@ -14,6 +14,7 @@ public enum PFPetSizeType: String, CustomStringConvertible
     case medium = "M"
     case large = "L"
     case xlarge = "XL"
+    case unknown
     
     public var description: String
     {
@@ -23,6 +24,7 @@ public enum PFPetSizeType: String, CustomStringConvertible
             case .medium: return "Medium"
             case .large: return "Large"
             case .xlarge: return "Extra Large"
+            case .unknown: return "Unknown"
         }
     }
 }


### PR DESCRIPTION
The enums for pet gender only accounted for "M" and "F" coming back from the API.  In this specific crash, we were getting back "U".  Because the enum initializer was being force unwrapped, we got a crash.

I added in "unknown" enum cases for our enums and fixed the failable initializers to default to this unknown case if the initializer fails.

Also, I noticed a problem with breeds for some animals coming back as "unknown" on the detail VC.  This was because of a simple typo and has also been fixed.