### PR TITLE
Show zip code dialog if no zip code is saved in UserDefaults

### DIFF
--- a/PetAdoption-iOS/PetAdoption-iOS/Controllers/PetListingViewController.swift
+++ b/PetAdoption-iOS/PetAdoption-iOS/Controllers/PetListingViewController.swift
@@ -57,6 +57,10 @@ class PetListingViewController: UIViewController
         {
             loadPets()
         }
+        else
+        {
+            presentZipCodeAlertController()
+        }
     }
 
     ////////////////////////////////////////////////////////////


### PR DESCRIPTION
The first time the app is loaded, before the user has entered a zip code, we were being presented with a blank screen.  Eventually we will add an empty state view there, but for now, if there is no zip code saved to UserDefaults, we will present the zip code dialog.