### PR TITLE
Infinite Scrolling has been implmented (fixes #66)

### DIFF
--- a/PetAdoption-iOS/PetAdoption-iOS.xcodeproj/project.pbxproj
+++ b/PetAdoption-iOS/PetAdoption-iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		42C2522A1C8881DE00B2BE6D /* BackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C252291C8881DE00B2BE6D /* BackgroundView.swift */; };
 		42C2522C1C8899BD00B2BE6D /* TransparentNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C2522B1C8899BD00B2BE6D /* TransparentNavBar.swift */; };
 		90ADBC339006BDDE435B71C4 /* Pods_PetAdoption_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FCC61B47493AD9AFC8BA810 /* Pods_PetAdoption_iOS.framework */; };
+		942F6A6A205F46CD00F3179F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942F6A69205F46CD00F3179F /* Constants.swift */; };
+		942F6A6B205F46CD00F3179F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942F6A69205F46CD00F3179F /* Constants.swift */; };
 		94381A3D200594600002A649 /* PFPet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94381A3C200594600002A649 /* PFPet.swift */; };
 		94381A4520059A7D0002A649 /* PFAnimalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94381A4420059A7D0002A649 /* PFAnimalType.swift */; };
 		94381A4720059AD70002A649 /* PFPetOptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94381A4620059AD70002A649 /* PFPetOptionType.swift */; };
@@ -23,6 +25,7 @@
 		94586CAB2007AE57002B6084 /* PFPhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94586CAA2007AE57002B6084 /* PFPhoto.swift */; };
 		94586CAD2007AF6E002B6084 /* PFContact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94586CAC2007AF6E002B6084 /* PFContact.swift */; };
 		94586CAF200822BF002B6084 /* PFGender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94586CAE200822BF002B6084 /* PFGender.swift */; };
+		94A366432076F87E00E95524 /* LoadingPetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A366412076F87E00E95524 /* LoadingPetsView.swift */; };
 		94EA0483202BCF5B00AFCF55 /* apikey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94EA0482202BCF5B00AFCF55 /* apikey.plist */; };
 		94EA0484202BCF5B00AFCF55 /* apikey.plist in Resources */ = {isa = PBXBuildFile; fileRef = 94EA0482202BCF5B00AFCF55 /* apikey.plist */; };
 		97C5226AC9AFB7547023F371 /* Pods_PetAdoptionTransportKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CBB921F8A0328C363307C66E /* Pods_PetAdoptionTransportKit.framework */; };
@@ -149,6 +152,7 @@
 		5FCC61B47493AD9AFC8BA810 /* Pods_PetAdoption_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PetAdoption_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AAD5FEFC48F2F2A23F42E1D /* Pods-PetAdoption-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PetAdoption-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PetAdoption-iOS/Pods-PetAdoption-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		925933A48637FAFF5BE6240D /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		942F6A69205F46CD00F3179F /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		94381A3C200594600002A649 /* PFPet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFPet.swift; sourceTree = "<group>"; };
 		94381A4420059A7D0002A649 /* PFAnimalType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFAnimalType.swift; sourceTree = "<group>"; };
 		94381A4620059AD70002A649 /* PFPetOptionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFPetOptionType.swift; sourceTree = "<group>"; };
@@ -157,6 +161,7 @@
 		94586CAA2007AE57002B6084 /* PFPhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFPhoto.swift; sourceTree = "<group>"; };
 		94586CAC2007AF6E002B6084 /* PFContact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFContact.swift; sourceTree = "<group>"; };
 		94586CAE200822BF002B6084 /* PFGender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFGender.swift; sourceTree = "<group>"; };
+		94A366412076F87E00E95524 /* LoadingPetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LoadingPetsView.swift; path = Views/LoadingPetsView.swift; sourceTree = "<group>"; };
 		94EA0482202BCF5B00AFCF55 /* apikey.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = apikey.plist; sourceTree = "<group>"; };
 		AB77A283D0B7D820C44F8CAD /* Pods-PetAdoption-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PetAdoption-iOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-PetAdoption-iOS/Pods-PetAdoption-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		CBB921F8A0328C363307C66E /* Pods_PetAdoptionTransportKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PetAdoptionTransportKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -323,6 +328,8 @@
 		42BC91241D67C7AF00B3B8FD /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D013BFA61C717935007C8808 /* ImageGalleryView.swift */,
+				94A366412076F87E00E95524 /* LoadingPetsView.swift */,
 				D0950B0C1C6198C2002E198C /* HomePortraitCollectionViewLayout.swift */,
 				428A90A81D8441D5006B4259 /* HomeLandscapeCollectionViewLayout.swift */,
 				42C2522B1C8899BD00B2BE6D /* TransparentNavBar.swift */,
@@ -331,6 +338,14 @@
 				42070E081D7470A100B02BA2 /* DescriptionCell.swift */,
 			);
 			name = Views;
+			sourceTree = "<group>";
+		};
+		942F6A68205F46B600F3179F /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				942F6A69205F46CD00F3179F /* Constants.swift */,
+			);
+			name = Utilities;
 			sourceTree = "<group>";
 		};
 		94381A3B20058E100002A649 /* PetFinderAPI */ = {
@@ -413,6 +428,7 @@
 		D0950AC61C618C2F002E198C /* PetAdoption-iOS */ = {
 			isa = PBXGroup;
 			children = (
+				942F6A68205F46B600F3179F /* Utilities */,
 				42ACC1AB1D68A88C001C7C83 /* Protocols */,
 				42ACC1A81D689C82001C7C83 /* Extensions */,
 				D040884F1C94BD6100A53389 /* Resources */,
@@ -462,7 +478,6 @@
 			isa = PBXGroup;
 			children = (
 				D013BFA41C716B7E007C8808 /* ImageGalleryView.xib */,
-				D013BFA61C717935007C8808 /* ImageGalleryView.swift */,
 			);
 			name = Nibs;
 			sourceTree = "<group>";
@@ -702,7 +717,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0910;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Code For Orlando";
 				TargetAttributes = {
 					D0950AC31C618C2F002E198C = {
@@ -925,6 +940,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0E536791C70405D004794D8 /* SearchViewController.swift in Sources */,
+				942F6A6A205F46CD00F3179F /* Constants.swift in Sources */,
 				42ACC1AD1D68A8A3001C7C83 /* ReusableView.swift in Sources */,
 				42C2522C1C8899BD00B2BE6D /* TransparentNavBar.swift in Sources */,
 				42C2522A1C8881DE00B2BE6D /* BackgroundView.swift in Sources */,
@@ -938,6 +954,7 @@
 				428A90A91D8441D5006B4259 /* HomeLandscapeCollectionViewLayout.swift in Sources */,
 				D0950B0D1C6198C2002E198C /* HomePortraitCollectionViewLayout.swift in Sources */,
 				D0950AFB1C619146002E198C /* PetListingViewController.swift in Sources */,
+				94A366432076F87E00E95524 /* LoadingPetsView.swift in Sources */,
 				D0950B011C619172002E198C /* InfoViewController.swift in Sources */,
 				D040884B1C94B6CC00A53389 /* UIColor+Theme.swift in Sources */,
 			);
@@ -968,6 +985,7 @@
 				D4F2A7861D6A811600E92647 /* DateExtension.swift in Sources */,
 				D4F2A7641D6A1FEF00E92647 /* Behavior.swift in Sources */,
 				94586CAF200822BF002B6084 /* PFGender.swift in Sources */,
+				942F6A6B205F46CD00F3179F /* Constants.swift in Sources */,
 				D4F2A7591D6A1EAB00E92647 /* PTKMedicalShotStatus.swift in Sources */,
 				D4F2A7721D6A22EA00E92647 /* PTKDeclawed.swift in Sources */,
 				D4F2A7761D6A2C3700E92647 /* Location.swift in Sources */,
@@ -1064,12 +1082,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -1117,12 +1137,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;

--- a/PetAdoption-iOS/PetAdoption-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/PetAdoption-iOS/PetAdoption-iOS.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/PetAdoption-iOS/PetAdoption-iOS/Constants.swift
+++ b/PetAdoption-iOS/PetAdoption-iOS/Constants.swift
@@ -1,0 +1,24 @@
+//
+//  Constants.swift
+//  PetAdoption-iOS
+//
+//  Created by Kelii Martin on 3/18/18.
+//  Copyright © 2018 Code For Orlando. All rights reserved.
+//
+
+import Foundation
+
+public struct Constants
+{
+    ////////////////////////////////////////////////////////////
+    // MARK: - UserDefaults Keys
+    ////////////////////////////////////////////////////////////
+    
+    public static let ZIPCODE_KEY: String = "ZIPCODE"
+    
+    ////////////////////////////////////////////////////////////
+    // MARK: - Other constants
+    ////////////////////////////////////////////////////////////
+
+    public static let MAX_SEARCH_RESULTS = 2000
+}

--- a/PetAdoption-iOS/PetAdoption-iOS/Storyboards/PetListings.storyboard
+++ b/PetAdoption-iOS/PetAdoption-iOS/Storyboards/PetListings.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Qib-KM-1M4">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Qib-KM-1M4">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,7 +33,7 @@
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="VV9-WR-ags">
                                     <size key="itemSize" width="142" height="135"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="50" height="50"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
@@ -90,6 +90,23 @@
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
+                                <collectionReusableView key="sectionFooterView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" reuseIdentifier="LoadingPetsView" id="hhc-6g-crD" customClass="LoadingPetsView" customModule="PetAdoption_iOS" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="135" width="375" height="50"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="ZVA-7z-kzD">
+                                            <rect key="frame" x="169" y="6.5" width="37" height="37"/>
+                                            <color key="color" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </activityIndicatorView>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="ZVA-7z-kzD" firstAttribute="centerX" secondItem="hhc-6g-crD" secondAttribute="centerX" id="lnw-qQ-J2L"/>
+                                        <constraint firstItem="ZVA-7z-kzD" firstAttribute="centerY" secondItem="hhc-6g-crD" secondAttribute="centerY" id="qis-y5-p07"/>
+                                    </constraints>
+                                    <connections>
+                                        <outlet property="activityIndicator" destination="ZVA-7z-kzD" id="xdL-bc-t1i"/>
+                                    </connections>
+                                </collectionReusableView>
                             </collectionView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/PetAdoption-iOS/PetAdoption-iOS/Views/HomeLandscapeCollectionViewLayout.swift
+++ b/PetAdoption-iOS/PetAdoption-iOS/Views/HomeLandscapeCollectionViewLayout.swift
@@ -50,5 +50,6 @@ class HomeLandscapeCollectionViewLayout: UICollectionViewFlowLayout
         self.minimumInteritemSpacing = 0
         self.minimumLineSpacing = 0
         self.scrollDirection = .vertical
+        self.footerReferenceSize = CGSize(width: 0, height: 60)
     }
 }

--- a/PetAdoption-iOS/PetAdoption-iOS/Views/HomePortraitCollectionViewLayout.swift
+++ b/PetAdoption-iOS/PetAdoption-iOS/Views/HomePortraitCollectionViewLayout.swift
@@ -50,5 +50,6 @@ class HomePortraitCollectionViewLayout: UICollectionViewFlowLayout
 		self.minimumInteritemSpacing = 0
 		self.minimumLineSpacing = 0
 		self.scrollDirection = .vertical
+        self.footerReferenceSize = CGSize(width: 0, height: 60)
 	}
 }

--- a/PetAdoption-iOS/PetAdoption-iOS/Views/LoadingPetsView.swift
+++ b/PetAdoption-iOS/PetAdoption-iOS/Views/LoadingPetsView.swift
@@ -1,0 +1,14 @@
+//
+//  LoadingPetsView.swift
+//  PetAdoption-iOS
+//
+//  Created by Kelii Martin on 4/5/18.
+//  Copyright © 2018 Code For Orlando. All rights reserved.
+//
+
+import UIKit
+
+class LoadingPetsView: UICollectionReusableView, ReusableView
+{
+    @IBOutlet var activityIndicator: UIActivityIndicatorView!
+}

--- a/PetAdoption-iOS/PetAdoptionTransportKit/PFPet.swift
+++ b/PetAdoption-iOS/PetAdoptionTransportKit/PFPet.swift
@@ -55,7 +55,7 @@ public struct PFPet
                     case .noKids: self.isGoodWithKids = false
                     case .noDogs: self.isGoodWithDogs = false
                     case .noCats: self.isGoodWithCats = false
-                    default: print("")
+                    default: break
                 }
             }
         }
@@ -75,7 +75,7 @@ public struct PFPet
                             case .noKids: self.isGoodWithKids = false
                             case .noDogs: self.isGoodWithDogs = false
                             case .noCats: self.isGoodWithCats = false
-                            default: print("")
+                            default: break
                         }
                     }
 

--- a/PetAdoption-iOS/Pods/Pods.xcodeproj/project.pbxproj
+++ b/PetAdoption-iOS/Pods/Pods.xcodeproj/project.pbxproj
@@ -111,11 +111,11 @@
 		0D0533E4EC2277AAAC8888328EC5A64B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		0DFE5D7FD160BB7D354326EAD6110304 /* Result.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Result.swift; path = Source/Result.swift; sourceTree = "<group>"; };
 		103E16F73DBD5C2D999E69C5BBE39B48 /* Fabric.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Fabric.h; path = iOS/Fabric.framework/Headers/Fabric.h; sourceTree = "<group>"; };
-		1093C4662359AC4637C9CF41539C3287 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
-		12029AB05ED097A779C8F9DF71B54B25 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SwiftyJSON.framework; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1093C4662359AC4637C9CF41539C3287 /* SwiftyJSON.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SwiftyJSON.modulemap; sourceTree = "<group>"; };
+		12029AB05ED097A779C8F9DF71B54B25 /* SwiftyJSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftyJSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		15D6459DF08F0B4766D6A4A82248764E /* CLSAttributes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSAttributes.h; path = iOS/Crashlytics.framework/Headers/CLSAttributes.h; sourceTree = "<group>"; };
 		2068DDFB822F579F88477096B90687BE /* Answers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Answers.h; path = iOS/Crashlytics.framework/Headers/Answers.h; sourceTree = "<group>"; };
-		2072244BE0B94CA69E8A0398D834E957 /* Pods-PetAdoption-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-PetAdoption-iOS.modulemap"; sourceTree = "<group>"; };
+		2072244BE0B94CA69E8A0398D834E957 /* Pods-PetAdoption-iOS.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-PetAdoption-iOS.modulemap"; sourceTree = "<group>"; };
 		255CECBE97E311DC45B1551080D15FEE /* SwiftyJSON.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftyJSON.swift; path = Source/SwiftyJSON.swift; sourceTree = "<group>"; };
 		275500BDAE3CEEE2E0EE3128EEAC1732 /* ParameterEncoding.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ParameterEncoding.swift; path = Source/ParameterEncoding.swift; sourceTree = "<group>"; };
 		283881BF270ECC795110DD8999231067 /* NetworkReachabilityManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkReachabilityManager.swift; path = Source/NetworkReachabilityManager.swift; sourceTree = "<group>"; };
@@ -131,25 +131,25 @@
 		57244F9CA89FC8C85EA2499B1582262C /* Pods-PetAdoption-iOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PetAdoption-iOS.release.xcconfig"; sourceTree = "<group>"; };
 		5918B59AF65572B3F898C84329B6A268 /* Alamofire-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-prefix.pch"; sourceTree = "<group>"; };
 		5C30B0C7A92AAE989BEE607B263CA84E /* Pods-PetAdoption-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PetAdoption-iOS.debug.xcconfig"; sourceTree = "<group>"; };
-		5D36A2178FC3DB37E25A03AF7ADA856F /* Alamofire.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Alamofire.modulemap; sourceTree = "<group>"; };
+		5D36A2178FC3DB37E25A03AF7ADA856F /* Alamofire.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Alamofire.modulemap; sourceTree = "<group>"; };
 		60068CEDE16B8A26B10B5878187B381E /* Alamofire-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Alamofire-umbrella.h"; sourceTree = "<group>"; };
 		62329700913CFB087223C21462973569 /* AlamofireImage-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AlamofireImage-umbrella.h"; sourceTree = "<group>"; };
 		66A21A62DB1FFDA384D6D8957F45BB1B /* Pods-PetAdoptionTransportKit-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PetAdoptionTransportKit-acknowledgements.plist"; sourceTree = "<group>"; };
 		6E50569EE86C6AA232243EAE226A8EB7 /* Pods-PetAdoption-iOS-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PetAdoption-iOS-umbrella.h"; sourceTree = "<group>"; };
 		706C7AFFE37BA158C3553250F4B5FAED /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		725EFA30BB31202FFFE0FA01CF3283B2 /* TaskDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskDelegate.swift; path = Source/TaskDelegate.swift; sourceTree = "<group>"; };
-		76587ED7FADD01CA06815D299A213D80 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Alamofire.framework; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		76587ED7FADD01CA06815D299A213D80 /* Alamofire.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alamofire.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7809AD751D1D2459E9543AFCD9325CFC /* Pods-PetAdoption-iOS-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-PetAdoption-iOS-resources.sh"; sourceTree = "<group>"; };
-		792F81D17EB889933C4A03CAFD480A77 /* Pods_PetAdoption_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_PetAdoption_iOS.framework; path = "Pods-PetAdoption-iOS.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		792F81D17EB889933C4A03CAFD480A77 /* Pods_PetAdoption_iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PetAdoption_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DAB1C3B54D308EF75E000F8CA1C9463 /* Validation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Validation.swift; path = Source/Validation.swift; sourceTree = "<group>"; };
 		7DFB579DA983A07D7F8A89DAF2DCED5D /* Alamofire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Alamofire.swift; path = Source/Alamofire.swift; sourceTree = "<group>"; };
-		7FE4ED734D5DCD4873E1E1DBEFA5D38F /* Pods-PetAdoptionTransportKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-PetAdoptionTransportKit.modulemap"; sourceTree = "<group>"; };
+		7FE4ED734D5DCD4873E1E1DBEFA5D38F /* Pods-PetAdoptionTransportKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-PetAdoptionTransportKit.modulemap"; sourceTree = "<group>"; };
 		8141650C4471BF29723EB09EE067DB9F /* Response.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Response.swift; path = Source/Response.swift; sourceTree = "<group>"; };
 		86D59B1423C8287E3ACF6FD2986905B6 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Crashlytics.framework; path = iOS/Crashlytics.framework; sourceTree = "<group>"; };
 		8B25EC3C9F21444560FDBD39D80A68B5 /* ServerTrustPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServerTrustPolicy.swift; path = Source/ServerTrustPolicy.swift; sourceTree = "<group>"; };
 		8BAED9D987D945BF6FEECEFAA2FB6FF9 /* AlamofireImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "AlamofireImage-dummy.m"; sourceTree = "<group>"; };
 		8F8882F5516A99AA41F93D90703A10A6 /* Pods-PetAdoptionTransportKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PetAdoptionTransportKit.release.xcconfig"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		966AE5EAC6160F2863605F8689A5715E /* CLSReport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CLSReport.h; path = iOS/Crashlytics.framework/Headers/CLSReport.h; sourceTree = "<group>"; };
 		9758F14AF343CB493CDCEA5E87243DA9 /* DispatchQueue+Alamofire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Alamofire.swift"; path = "Source/DispatchQueue+Alamofire.swift"; sourceTree = "<group>"; };
 		9CB41DA3F90A4B85448A07CE63E5E3B7 /* Pods-PetAdoptionTransportKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PetAdoptionTransportKit.debug.xcconfig"; sourceTree = "<group>"; };
@@ -166,7 +166,7 @@
 		B0F8F2C4D8A3DCC28643E146BFF55EC7 /* ImageFilter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageFilter.swift; path = Source/ImageFilter.swift; sourceTree = "<group>"; };
 		B47F429028D769F32B7B7E5B8088B3B4 /* SwiftyJSON.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SwiftyJSON.xcconfig; sourceTree = "<group>"; };
 		B6557949B1F3E8E473B0B3D31EC85BD6 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		BABF35DBFB5CC69269DD86DF0AEF94B5 /* AlamofireImage.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = AlamofireImage.modulemap; sourceTree = "<group>"; };
+		BABF35DBFB5CC69269DD86DF0AEF94B5 /* AlamofireImage.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = AlamofireImage.modulemap; sourceTree = "<group>"; };
 		BE1D5A052E5EF602D3224DAD6E3018E0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BF1CE7B049D454437317A8D49D3FD384 /* Image.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Image.swift; path = Source/Image.swift; sourceTree = "<group>"; };
 		BFBE2C0646A225D887854C5B6267CD5E /* SwiftyJSON-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-prefix.pch"; sourceTree = "<group>"; };
@@ -176,11 +176,11 @@
 		CA0BA3306E9190272924F938E212D10A /* Pods-PetAdoptionTransportKit-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PetAdoptionTransportKit-dummy.m"; sourceTree = "<group>"; };
 		D31CA9303BA08425F24FC8FC26D783C6 /* Alamofire-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Alamofire-dummy.m"; sourceTree = "<group>"; };
 		D7706F7EDDE5F23D6D649F7EE08894C8 /* SwiftyJSON-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "SwiftyJSON-umbrella.h"; sourceTree = "<group>"; };
-		DBBF022A3CC12906ABF7D6699E9E2A54 /* Pods_PetAdoptionTransportKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_PetAdoptionTransportKit.framework; path = "Pods-PetAdoptionTransportKit.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DBBF022A3CC12906ABF7D6699E9E2A54 /* Pods_PetAdoptionTransportKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PetAdoptionTransportKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E0F4DC34DE573F18ADEDAC6AFF4E3BDF /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fabric.framework; path = iOS/Fabric.framework; sourceTree = "<group>"; };
 		E4BDF36C7E77F5F7E2A2FD5BBC502E39 /* AFError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AFError.swift; path = Source/AFError.swift; sourceTree = "<group>"; };
 		E74E69128AD7339893CEF017891BFB85 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		E84C9494682FA4735BEBF09583DE7784 /* AlamofireImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = AlamofireImage.framework; path = AlamofireImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E84C9494682FA4735BEBF09583DE7784 /* AlamofireImage.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AlamofireImage.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9DAFFB588F574670327410FF580F0B2 /* ImageCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImageCache.swift; path = Source/ImageCache.swift; sourceTree = "<group>"; };
 		EDBEB3DE427DD96ED44DCD202D05BC9C /* Request.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Request.swift; path = Source/Request.swift; sourceTree = "<group>"; };
 		F3B94F0C5A35539F2F2012B27C1D24AD /* AlamofireImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "AlamofireImage-prefix.pch"; sourceTree = "<group>"; };
@@ -263,7 +263,6 @@
 				103E16F73DBD5C2D999E69C5BBE39B48 /* Fabric.h */,
 				E48F36B813DFDA30E88D358B2ACA46A6 /* Frameworks */,
 			);
-			name = Fabric;
 			path = Fabric;
 			sourceTree = "<group>";
 		};
@@ -273,7 +272,6 @@
 				255CECBE97E311DC45B1551080D15FEE /* SwiftyJSON.swift */,
 				F64C32B50F96B8EA00BF5B4837E86649 /* Support Files */,
 			);
-			name = SwiftyJSON;
 			path = SwiftyJSON;
 			sourceTree = "<group>";
 		};
@@ -320,7 +318,6 @@
 				A8C2632DA285F55005880269112BD1BE /* Crashlytics.h */,
 				CF871AC18ED85EC1C7C649583CD1F4F1 /* Frameworks */,
 			);
-			name = Crashlytics;
 			path = Crashlytics;
 			sourceTree = "<group>";
 		};
@@ -396,7 +393,6 @@
 				9F50E6D137DDC7E90F6D5619960A101E /* UIImageView+AlamofireImage.swift */,
 				5146CF975E76DC82E4E92D3F51636784 /* Support Files */,
 			);
-			name = AlamofireImage;
 			path = AlamofireImage;
 			sourceTree = "<group>";
 		};
@@ -422,7 +418,6 @@
 				7DAB1C3B54D308EF75E000F8CA1C9463 /* Validation.swift */,
 				FE5FF554041C3D3CEEF81A3E41F4F6CA /* Support Files */,
 			);
-			name = Alamofire;
 			path = Alamofire;
 			sourceTree = "<group>";
 		};
@@ -615,7 +610,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0930;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -834,6 +829,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -841,6 +837,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -1019,6 +1016,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -1026,6 +1024,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;


### PR DESCRIPTION
No longer are we constrained to the first 25 pets returned by PetFinder!  Infinite scrolling has been implemented to allow the app to retrieve the next set of results when they reach the bottom of the collection view.  Due to a usage limit imposed by PetFinder, we are only ever able to see 2000 search results.  That constraint has been added to the code as well.

While implementing these changes, I also cleaned up some code, including creating a Constants file for constants that might be needed throughout, as well as updating the PTKRequestManager to accommodate for retrieving and passing an offset to and from the API, and adjusting the code in the PetListingViewController to handle the infinite scroll in a UX-friendly manner (added an activity indicator to the bottom that will show as new results are being loaded in, etc)