### PR TITLE
Stop activity indicator for pet listings with no image

### DIFF
--- a/PetAdoption-iOS/PetAdoption-iOS/Views/PetCell.swift
+++ b/PetAdoption-iOS/PetAdoption-iOS/Views/PetCell.swift
@@ -76,6 +76,8 @@ public class PetCell: UICollectionViewCell, ReusableView
             { image, error in
                 self.populateCell(image: image)
             }
+        } else {
+            self.activityIndicator.stopAnimating()
         }
     }
 


### PR DESCRIPTION
The activity indicator would keep spinning for listings that had no image, making it seem like an image was still loading.